### PR TITLE
Add switch for Bluetooth devices list

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/ui/feature/chart/ChartScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/chart/ChartScreen.kt
@@ -21,6 +21,7 @@ import com.softteco.template.Constants.SPACE_STRING
 import com.softteco.template.MainActivity
 import com.softteco.template.R
 import com.softteco.template.ui.components.CustomTopAppBar
+import com.softteco.template.ui.theme.Dimens
 import com.softteco.template.ui.theme.Dimens.PaddingDefault
 import com.softteco.template.ui.theme.Dimens.PaddingExtraLarge
 import com.softteco.template.utils.BluetoothHelper
@@ -83,7 +84,7 @@ fun Charts(
     val humColor by remember { mutableIntStateOf(generateRandomColor()) }
 
     Column(
-        modifier = modifier
+        modifier = modifier.padding(start = Dimens.PaddingDefault)
     ) {
         Text(
             text = stringResource(R.string.temperature).plus(SPACE_STRING)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="bluetooth_icon_description">Baseline_bluetooth_24</string>
     <string name="signal_level_icon_description">Baseline_signal_level_24</string>
     <string name="device_name">LYWSD03MMC</string>
+    <string name="show_only_thermometers">Show only thermometers</string>
 
     <!-- Chart screen -->
     <string name="temperature">Temperature:</string>


### PR DESCRIPTION
## Summary

- Added a switch to display items in the list of Bluetooth devices.

## Reasons

Necessary to filter the list and display only Bluetooth thermometers or all available devices.

## References

closes #14