### PR TITLE
Enable CI pipelines for the smart_home branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "smart_home" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "smart_home" ]
 
 jobs:
   detekt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "smart_home" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "smart_home" ]
 
 jobs:
   unit_testing:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img src="app/src/main/ic_launcher-playstore.png" alt="icon" width="100"/>
 
 # Template
-![test workflow](https://github.com/SoftTeco/AndroidAppTemplate/actions/workflows/test.yml/badge.svg)
-[![codecov](https://codecov.io/gh/SoftTeco/AndroidAppTemplate/graph/badge.svg)](https://codecov.io/gh/SoftTeco/AndroidAppTemplate)
-![lint workflow](https://github.com/SoftTeco/AndroidAppTemplate/actions/workflows/lint.yml/badge.svg)
+![test workflow](https://github.com/SoftTeco/AndroidBLE/actions/workflows/test.yml/badge.svg)
+[![codecov](https://codecov.io/gh/SoftTeco/AndroidBLE/graph/badge.svg)](https://codecov.io/gh/SoftTeco/AndroidBLE)
+![lint workflow](https://github.com/SoftTeco/AndroidBLE/actions/workflows/lint.yml/badge.svg)
 
 Sample application to demonstrate usage of Jetpack Compose, Kotlin Flow, Android Hilt, etc.
 


### PR DESCRIPTION
## Summary

The **smart_home** branch has been added as a target for the **test** and **lint** pipelines

## Reasons

Since we will use the smart_home branch as the main branch, it is necessary to run CI testing and static analysis pipelines on it

## References

- closes #30 