### PR TITLE
Implement navigation to the device dashboard

### DIFF
--- a/app/src/main/kotlin/com/softteco/template/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/com/softteco/template/navigation/AppNavHost.kt
@@ -10,13 +10,21 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
+import com.softteco.template.data.device.Device.Type.RobotVacuum
+import com.softteco.template.data.device.Device.Type.TemperatureAndHumidity
 import com.softteco.template.navigation.AppNavHost.DEEP_LINK_URI
+import com.softteco.template.navigation.AppNavHost.DEVICE_ID_KEY
 import com.softteco.template.navigation.AppNavHost.RESET_PASSWORD_PATH
 import com.softteco.template.navigation.AppNavHost.RESET_TOKEN_ARG
+import com.softteco.template.ui.feature.deviceDashboard.deviceSettings.DeviceSettingsScreen
+import com.softteco.template.ui.feature.deviceDashboard.devices.robotVacuum.RobotVacuumDashboardScreen
+import com.softteco.template.ui.feature.deviceDashboard.devices.thermometer.ThermometerDashboardScreen
 import com.softteco.template.ui.feature.forgotPassword.ForgotPasswordScreen
 import com.softteco.template.ui.feature.home.HomeScreen
 import com.softteco.template.ui.feature.home.device.connection.AddNewDeviceScreen
@@ -36,6 +44,7 @@ object AppNavHost {
     const val DEEP_LINK_URI = "https://template.softteco.com.deep_link"
     const val RESET_PASSWORD_PATH = "reset_password"
     const val RESET_TOKEN_ARG = "token"
+    const val DEVICE_ID_KEY = "device_id"
 }
 
 @Composable
@@ -73,7 +82,18 @@ fun NavGraphBuilder.bottomBarGraph(
                 onAddNewClick = { navController.navigate(Screen.AddNewDevice.route) },
                 onSearchClick = { navController.navigate(Screen.Search.route) },
                 onNotificationsClick = { navController.navigate(Screen.Notifications.route) },
-                onDeviceClick = { /*TODO*/ },
+                onDeviceClick = { device ->
+                    val deviceId = device.id.toString()
+                    when (device.type) {
+                        TemperatureAndHumidity -> {
+                            navController.navigate(Screen.ThermometerDashboard.createRoute(deviceId))
+                        }
+                        RobotVacuum -> {
+                            navController.navigate(Screen.RobotVacuumDashboard.createRoute(deviceId))
+                        }
+                        else -> { /*TODO*/ }
+                    }
+                }
             )
         }
         composable(Screen.Profile.route) {
@@ -200,6 +220,39 @@ fun NavGraphBuilder.homeGraph(navController: NavController, modifier: Modifier =
         }
         composable(Screen.Notifications.route) {
             NotificationsScreen(onBackClicked = { navController.navigateUp() }, modifier)
+        }
+        composable(
+            route = Screen.ThermometerDashboard.route,
+            arguments = listOf(navArgument(DEVICE_ID_KEY) { type = NavType.StringType })
+        ) {
+            ThermometerDashboardScreen(
+                onSettingsClick = { deviceId ->
+                    navController.navigate(Screen.DeviceSettings.createRoute(deviceId))
+                },
+                onBackClicked = { navController.navigateUp() },
+                modifier = modifier,
+            )
+        }
+        composable(
+            route = Screen.RobotVacuumDashboard.route,
+            arguments = listOf(navArgument(DEVICE_ID_KEY) { type = NavType.StringType })
+        ) {
+            RobotVacuumDashboardScreen(
+                onSettingsClick = { deviceId ->
+                    navController.navigate(Screen.DeviceSettings.createRoute(deviceId))
+                },
+                onBackClicked = { navController.navigateUp() },
+                modifier = modifier,
+            )
+        }
+        composable(
+            route = Screen.DeviceSettings.route,
+            arguments = listOf(navArgument(DEVICE_ID_KEY) { type = NavType.StringType })
+        ) {
+            DeviceSettingsScreen(
+                onBackClicked = { navController.navigateUp() },
+                modifier = modifier,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/softteco/template/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/softteco/template/navigation/Screen.kt
@@ -1,5 +1,7 @@
 package com.softteco.template.navigation
 
+import com.softteco.template.navigation.AppNavHost.DEVICE_ID_KEY
+
 sealed class Screen(val route: String) {
     data object Home : Screen("home")
 
@@ -18,4 +20,16 @@ sealed class Screen(val route: String) {
     data object ResetPassword : Screen("reset_password")
     data object ForgotPassword : Screen("forgot_password")
     data object OpenSourceLicenses : Screen("open_source_licenses")
+
+    data object ThermometerDashboard : Screen("thermometer_dashboard/{$DEVICE_ID_KEY}") {
+        fun createRoute(deviceId: String) = "thermometer_dashboard/$deviceId"
+    }
+
+    data object RobotVacuumDashboard : Screen("robot_vacuum_dashboard/{$DEVICE_ID_KEY}") {
+        fun createRoute(deviceId: String) = "robot_vacuum_dashboard/$deviceId"
+    }
+
+    data object DeviceSettings : Screen("device_settings/{$DEVICE_ID_KEY}") {
+        fun createRoute(deviceId: String) = "device_settings/$deviceId"
+    }
 }

--- a/app/src/main/kotlin/com/softteco/template/ui/components/DeviceDashboardTopAppBar.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/components/DeviceDashboardTopAppBar.kt
@@ -1,0 +1,45 @@
+package com.softteco.template.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.softteco.template.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeviceDashboardTopAppBar(
+    title: String,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit = {},
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = { Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+        navigationIcon = {
+            IconButton(onClick = { onBackClicked() }) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.back_description)
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = stringResource(R.string.device_settings)
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/deviceSettings/DeviceSettingsScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/deviceSettings/DeviceSettingsScreen.kt
@@ -1,0 +1,91 @@
+package com.softteco.template.ui.feature.deviceDashboard.deviceSettings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.softteco.template.R
+import com.softteco.template.ui.theme.AppTheme
+import com.softteco.template.ui.theme.Dimens
+import java.util.UUID
+
+@Composable
+fun DeviceSettingsScreen(
+    onBackClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: DeviceSettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    ScreenContent(
+        state = state,
+        modifier = modifier,
+        onBackClicked = onBackClicked,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScreenContent(
+    state: DeviceSettingsViewModel.State,
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        TopAppBar(
+            title = { Text(stringResource(R.string.settings)) },
+            navigationIcon = {
+                IconButton(onClick = onBackClicked) {
+                    Icon(Icons.Outlined.ArrowBack, stringResource(R.string.back_description))
+                }
+            },
+            modifier = Modifier.statusBarsPadding()
+        )
+        Column(
+            modifier = Modifier.padding(Dimens.PaddingNormal),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "DeviceSettings ${state.deviceId}",
+                style = TextStyle(textAlign = TextAlign.Center),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    AppTheme {
+        ScreenContent(
+            state = DeviceSettingsViewModel.State(UUID.randomUUID().toString()),
+            onBackClicked = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/deviceSettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/deviceSettings/DeviceSettingsViewModel.kt
@@ -1,0 +1,21 @@
+package com.softteco.template.ui.feature.deviceDashboard.deviceSettings
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.softteco.template.navigation.AppNavHost
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class DeviceSettingsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val deviceId = checkNotNull(savedStateHandle.get<String>(AppNavHost.DEVICE_ID_KEY))
+
+    val state = MutableStateFlow(State(deviceId))
+
+    @Immutable
+    data class State(val deviceId: String)
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/robotVacuum/RobotVacuumDashboardScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/robotVacuum/RobotVacuumDashboardScreen.kt
@@ -1,0 +1,84 @@
+package com.softteco.template.ui.feature.deviceDashboard.devices.robotVacuum
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.softteco.template.ui.components.DeviceDashboardTopAppBar
+import com.softteco.template.ui.theme.AppTheme
+import com.softteco.template.ui.theme.Dimens
+import java.util.UUID
+
+@Composable
+fun RobotVacuumDashboardScreen(
+    onSettingsClick: (deviceId: String) -> Unit,
+    onBackClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RobotVacuumDashboardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    ScreenContent(
+        state,
+        onSettingsClick = onSettingsClick,
+        modifier = modifier,
+        onBackClicked = onBackClicked,
+    )
+}
+
+@Composable
+private fun ScreenContent(
+    state: RobotVacuumDashboardViewModel.State,
+    onSettingsClick: (deviceId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        DeviceDashboardTopAppBar(
+            state.deviceId,
+            onSettingsClick = { onSettingsClick(state.deviceId) },
+            modifier = Modifier.fillMaxWidth(),
+            onBackClicked = onBackClicked
+        )
+        Column(
+            modifier = Modifier.padding(Dimens.PaddingNormal),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "RobotVacuumDashboard",
+                style = TextStyle(textAlign = TextAlign.Center),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    AppTheme {
+        ScreenContent(
+            state = RobotVacuumDashboardViewModel.State(UUID.randomUUID().toString()),
+            onSettingsClick = {},
+            onBackClicked = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/robotVacuum/RobotVacuumDashboardViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/robotVacuum/RobotVacuumDashboardViewModel.kt
@@ -1,0 +1,22 @@
+package com.softteco.template.ui.feature.deviceDashboard.devices.robotVacuum
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.softteco.template.navigation.AppNavHost.DEVICE_ID_KEY
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class RobotVacuumDashboardViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val deviceId = checkNotNull(savedStateHandle.get<String>(DEVICE_ID_KEY))
+
+    val state = MutableStateFlow(State(deviceId))
+
+    @Immutable
+    data class State(val deviceId: String)
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/thermometer/ThermometerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/thermometer/ThermometerDashboardScreen.kt
@@ -1,0 +1,84 @@
+package com.softteco.template.ui.feature.deviceDashboard.devices.thermometer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.softteco.template.ui.components.DeviceDashboardTopAppBar
+import com.softteco.template.ui.theme.AppTheme
+import com.softteco.template.ui.theme.Dimens
+import java.util.UUID
+
+@Composable
+fun ThermometerDashboardScreen(
+    onSettingsClick: (deviceId: String) -> Unit,
+    onBackClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ThermometerDashboardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    ScreenContent(
+        state,
+        onSettingsClick = onSettingsClick,
+        modifier = modifier,
+        onBackClicked = onBackClicked,
+    )
+}
+
+@Composable
+private fun ScreenContent(
+    state: ThermometerDashboardViewModel.State,
+    onSettingsClick: (deviceId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.background)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(Dimens.PaddingExtraLarge),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        DeviceDashboardTopAppBar(
+            state.deviceId,
+            onSettingsClick = { onSettingsClick(state.deviceId) },
+            modifier = Modifier.fillMaxWidth(),
+            onBackClicked = onBackClicked
+        )
+        Column(
+            modifier = Modifier.padding(Dimens.PaddingNormal),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "ThermometerDashboard",
+                style = TextStyle(textAlign = TextAlign.Center),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    AppTheme {
+        ScreenContent(
+            state = ThermometerDashboardViewModel.State(UUID.randomUUID().toString()),
+            onSettingsClick = {},
+            onBackClicked = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/thermometer/ThermometerDashboardViewModel.kt
+++ b/app/src/main/kotlin/com/softteco/template/ui/feature/deviceDashboard/devices/thermometer/ThermometerDashboardViewModel.kt
@@ -1,0 +1,22 @@
+package com.softteco.template.ui.feature.deviceDashboard.devices.thermometer
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.softteco.template.navigation.AppNavHost.DEVICE_ID_KEY
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ThermometerDashboardViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val deviceId = checkNotNull(savedStateHandle.get<String>(DEVICE_ID_KEY))
+
+    val state = MutableStateFlow(State(deviceId))
+
+    @Immutable
+    data class State(val deviceId: String)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,4 +98,7 @@
     <string name="temperature_and_humidity">Temperature and Humidity Monitor</string>
     <string name="robot_vacuum_mop">Robot Vacuum-Mop</string>
     <string name="washing_machine">Washing Machine</string>
+
+    <!-- Device dashboard screen -->
+    <string name="device_settings">Device settings</string>
 </resources>


### PR DESCRIPTION
## Summary

- Implemented navigation from the Home screen to the Device Dashboard screen.
- Navigation is based on device type and opens a specific Dashboard.
- Implement multiple Dashboard screen stub screens for different types of devices to test navigation.
- Implement a screen stub for Device Settings and navigation to it.

## Reasons

As a user, I want to be able to open the dashboard of a specific device to control it and view data.

## References

- closes #35 